### PR TITLE
new kalman filter predictions

### DIFF
--- a/timecorr/helpers.py
+++ b/timecorr/helpers.py
@@ -244,7 +244,7 @@ def predict(x, n=1):
     '''
 
     if n == 0:
-        return x
+        return kf.em(x).smooth(x)[0]
 
     x_masked = np.ma.MaskedArray(np.vstack((x, np.tile(np.nan, (1, x.shape[1])))))
     x_masked[-1, :] = np.ma.masked


### PR DESCRIPTION
added ability to forward predict for an arbitrary number of timepoints.

or, when n-future-timepoints is 0, return a smoothed version of the observed data.