### PR TITLE
weights and filters

### DIFF
--- a/timecorr/__init__.py
+++ b/timecorr/__init__.py
@@ -3,7 +3,6 @@
 from .timecorr import timecorr
 from .helpers import isfc, wisfc, autofc, wcorr, gaussian_weights, gaussian_params, mat2vec, vec2mat, laplace_weights,\
                      laplace_params, format_data, t_weights, t_params, mexican_hat_weights,\
-                     mexican_hat_params, eye_weights, eye_params, uniform_weights, uniform_params,\ boxcar_weights, boxcar_params,\
+                     mexican_hat_params, eye_weights, eye_params, uniform_weights, uniform_params, boxcar_weights, boxcar_params,\
                      mean_combine, corrmean_combine, tstat_combine, null_combine, reduce, isodd, iseven, smooth, timepoint_decoder,\
                      optimize_weighted_timepoint_decoder
- 

--- a/timecorr/helpers.py
+++ b/timecorr/helpers.py
@@ -12,8 +12,6 @@ import pandas as pd
 import warnings
 from matplotlib import pyplot as plt
 
-from copy import copy, deepcopy
-
 graph_measures = {'eigenvector_centrality': bc.centrality.eigenvector_centrality_und,
                   'pagerank_centrality': lambda x: bc.centrality.pagerank_centrality(x, d=0.85),
                   'strength': bc.degree.strengths_und}
@@ -80,7 +78,7 @@ def boxcar_weights(T, params=boxcar_params):
     if params is None:
         params = boxcar_params
 
-    return np.multiply(toeplitz(np.arange(T)) < params{'width'}/2., 1.)
+    return np.multiply(toeplitz(np.arange(T)) < params['width']/2., 1.)
 
 
 

--- a/timecorr/timecorr.py
+++ b/timecorr/timecorr.py
@@ -1,10 +1,11 @@
 # coding: utf-8
 
+import numpy as np
 from .helpers import isfc, gaussian_weights, format_data, null_combine, reduce, smooth
 
 def timecorr(data, weights_function=gaussian_weights,
-             weights_params=None, combine=null_combine,
-             cfun=isfc, rfun=None):
+             weights_params=None, include_timepoints='all', exclude_timepoints=None,
+             combine=null_combine, cfun=isfc, rfun=None):
     """
     Computes dynamics correlations in single-subject or multi-subject data.
 
@@ -30,6 +31,22 @@ def timecorr(data, weights_function=gaussian_weights,
         Default: None (use default parameters for the given weights function).
         Options: gaussian_params, laplace_params, t_params, eye_params,
         mexican_hat_params.
+
+    include_timepoints: determines which timepoints are used to estimate the correlations
+        at each timepoint.  This is applied after the weights function to further constrain
+        which timepoints may be considered in computing the correlations at each timepoint.
+
+        Options: 'all' (default; include all timepoints), 'pre' (only include timepoints *before*
+        the given timepoint), 'post' (only include timepoints *after* the given timepoint).
+
+    exclude_timepoints: additional option, used to filter out any timepoints less than x units
+        of the timepoint whose correlations are being estimated.  For example, passing
+        exclude_timepoints=3 will exclude any timepoints 3 or more samples from the given timepoint.
+        When exclude timepoints is negative, it works inversely-- e.g. exclude_timepoints=-5 will
+        exclude any timepoints within 5 or fewer samples of the given timepoint.  Real-valued scalars
+        are supported but are rounded to the nearest Integer.
+
+        Default: None (no filtering).
 
     combine: a function applied to either a single matrix of vectorized correlation
         matrices, or a list of such matrices.  The function should return either
@@ -88,6 +105,16 @@ def timecorr(data, weights_function=gaussian_weights,
     corrmats: moment-by-moment correlations
     """
 
+    def temporal_filter(T, k):
+        k = np.round(k)
+        filt = np.eye(T)
+        for i in np.arange(1, np.min([np.abs(k) + 1, T])):
+            filt = filt + np.eye(T, k=np.abs(i)) + np.eye(T, k=-np.abs(i))
+        if k < 0:
+            return 1 - filt
+        else:
+            return filt
+
     if type(data) == list:
         T = data[0].shape[0]
         return_list = True
@@ -100,14 +127,25 @@ def timecorr(data, weights_function=gaussian_weights,
 
     weights = weights_function(T, weights_params)
 
+    include_timepoints = include_timepoints.lower()
+    if include_timepoints == 'all':
+        pass
+    elif include_timepoints == 'pre':
+        weights = np.tril(weights)
+    elif include_timepoints == 'post':
+        weights = np.triu(weights)
+    else:
+        raise Exception(f'Invalid option for include_timepoints: \'{include_timepoints}\'.  Must be one of: \'all\', \'pre\', or \'post\'.')
+
+    if not (exclude_timepoints is None):
+        weights = np.multiply(temporal_filter(T, exclude_timepoints), weights)
+
     if cfun:
         corrs = reduce(combine(cfun(data, weights)), rfun=rfun)
 
         if not (cfun is None):
             return_list = False
 
-        #if type(corrs) is not list:
-        #    corrs = corrs.tolist()
     else:
         corrs = combine(smooth(data, kernel_fun=weights_function, kernel_params=weights_params)).tolist()
 


### PR DESCRIPTION
- added a new type of weights function, `boxcar_weights` (equivalent to a sliding window, but forgiving of endpoints)
- added two new flags to `timecorr`:
  - `include_timepoints`: allows the user control over which timepoints are included when estimating a given timepoint's correlations.  When `include_timepoints=='all'` (default), no filtering is performed.  When `include_timepoints=='pre'`, only timepoints *before* the given timepoint are included; when `include_timepoints=='post'`, only timepoints *after* the given timepoint are included.  This filter is applied after the per-timepoint weights are calculated.  This is useful for approximating "causality" sorts of measures, e.g. by separating out which time-varying features affected by (or affect) which other features, in each moment.
  - `exclude_timepoints`: allows the user to filter out timepoints beyond a particular temporal distance (specified in samples) from the current timepoint.  For example, passing `exclude_timepoints=3` will exclude any timepoints 3 or more samples from the given timepoint.  When exclude timepoints is negative, it works inversely-- e.g. `exclude_timepoints=-5` will exclude any timepoints within 5 or fewer samples of the given timepoint.  Real-valued scalars are supported but are rounded to the nearest Integer.